### PR TITLE
add facter package to mpich-3.3.1 install script

### DIFF
--- a/elements/mpich-3.3.1/post-install.d/05-mpich
+++ b/elements/mpich-3.3.1/post-install.d/05-mpich
@@ -14,6 +14,9 @@ set -o pipefail
 MPICH_TMP_FOLDER=/root/tmp
 mkdir -p $MPICH_TMP_FOLDER
 
+# facter is used for hostfile generation in complex appliances
+yum install facter
+
 #############################################################
 # Installation
 #############################################################


### PR DESCRIPTION
facter is used for hostfile generation in complex appliances.